### PR TITLE
BUILDENV: Se till att cypress failar om något går fel i testerna

### DIFF
--- a/test/scripts/run.js
+++ b/test/scripts/run.js
@@ -25,15 +25,19 @@ const cypressOption = {
 };
 
 cypress.run(cypressOption).then(
-    () => {
-    generateReport(options)
-},
-    error => {
-    generateReport(options)
-    console.error(error)
-    process.exit(1)
-}
-)
+  (results) => {
+    //console.log(results);
+    generateReport(options);
+
+    if (results.totalFailed > 0) {
+      process.exit(1)
+    }
+  }
+).catch(error => {
+  generateReport(options);
+  console.error(error);
+  process.exit(1)
+});
 
 function generateReport(options) {
     return merge(options).then(report => marge.create(report, options))


### PR DESCRIPTION
Upptäcktes vid införandet av cypress tester i IB att de alltid rapporterade grönt när man körde via gradle